### PR TITLE
Improve test coverage for encode.ts file

### DIFF
--- a/src/encode.test.ts
+++ b/src/encode.test.ts
@@ -84,6 +84,12 @@ describe("encode - headerBysquare", function() {
 			headerBysquare([invalidValue, Version["1.0.0"], 0x00, 0x00]);
 		}, new EncodeError(EncodeErrorMessage.BySquareType, { invalidValue }));
 	});
+	test("throw EncodeError when creating an bysquare header with invalid version", () => {
+		const invalidValue = 0xFF;
+		assert.throws(() => {
+			headerBysquare([0x00, invalidValue, 0x00, 0x00]);
+		}, new EncodeError(EncodeErrorMessage.Version, { invalidValue }));
+	});
 });
 
 test("encode - binary header", () => {

--- a/src/encode.test.ts
+++ b/src/encode.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert";
-import test from "node:test";
+import test, { describe } from "node:test";
 
 import { decode } from "./decode.js";
 import {
 	addChecksum,
 	encode,
+	EncodeError,
+	EncodeErrorMessage,
 	headerBysquare,
 	serialize,
 } from "./encode.js";
@@ -12,6 +14,7 @@ import {
 	CurrencyCode,
 	DataModel,
 	PaymentOptions,
+	Version,
 } from "./types.js";
 
 export const payload = {
@@ -69,10 +72,18 @@ test("encode - create data with checksum", () => {
 	assert.deepEqual(checksum, expected);
 });
 
-test("encode - make bysquare header", () => {
-	const header = headerBysquare();
-	const expected = Uint8Array.from([0x00, 0x00]);
-	assert.deepEqual(header, expected);
+describe("encode - headerBysquare", function() {
+	test("make bysquare header", () => {
+		const header = headerBysquare();
+		const expected = Uint8Array.from([0x00, 0x00]);
+		assert.deepEqual(header, expected);
+	});
+	test("throw EncodeError when creating an bysquare header with invalid type", () => {
+		const invalidValue = 0x1F;
+		assert.throws(() => {
+			headerBysquare([invalidValue, Version["1.0.0"], 0x00, 0x00]);
+		}, new EncodeError(EncodeErrorMessage.BySquareType, { invalidValue }));
+	});
 });
 
 test("encode - binary header", () => {

--- a/src/encode.test.ts
+++ b/src/encode.test.ts
@@ -116,7 +116,16 @@ describe("encode - headerDataLength", function() {
 			new Uint8Array(dataView.buffer),
 		);
 	});
-	test("throw, when length is too big", function() {
+	test("throw EncodeError, when allowed size of header is exceeded", function() {
+		assert.throws(
+			() => {
+				headerDataLength(MAX_COMPRESSED_SIZE);
+			},
+			new EncodeError(EncodeErrorMessage.HeaderDataSize, {
+				actualSize: MAX_COMPRESSED_SIZE,
+				allowedSize: MAX_COMPRESSED_SIZE,
+			}),
+		);
 	});
 });
 

--- a/src/encode.test.ts
+++ b/src/encode.test.ts
@@ -74,7 +74,7 @@ test("encode - create data with checksum", () => {
 	assert.deepEqual(checksum, expected);
 });
 
-describe("encode - headerBysquare", function() {
+describe("encode - headerBysquare", () => {
 	test("make bysquare header", () => {
 		const header = headerBysquare();
 		const expected = Uint8Array.from([0x00, 0x00]);
@@ -106,8 +106,8 @@ describe("encode - headerBysquare", function() {
 	});
 });
 
-describe("encode - headerDataLength", function() {
-	test("return encoded header data length", function() {
+describe("encode - headerDataLength", () => {
+	test("return encoded header data length", () => {
 		const length = MAX_COMPRESSED_SIZE - 1;
 		const dataView = new DataView(new ArrayBuffer(2));
 		dataView.setUint16(0, length, true);
@@ -116,7 +116,7 @@ describe("encode - headerDataLength", function() {
 			new Uint8Array(dataView.buffer),
 		);
 	});
-	test("throw EncodeError, when allowed size of header is exceeded", function() {
+	test("throw EncodeError, when allowed size of header is exceeded", () => {
 		assert.throws(
 			() => {
 				headerDataLength(MAX_COMPRESSED_SIZE);

--- a/src/encode.test.ts
+++ b/src/encode.test.ts
@@ -90,6 +90,18 @@ describe("encode - headerBysquare", function() {
 			headerBysquare([0x00, invalidValue, 0x00, 0x00]);
 		}, new EncodeError(EncodeErrorMessage.Version, { invalidValue }));
 	});
+	test("throw EncodeError when creating an bysquare header with invalid document type", () => {
+		const invalidValue = 0xFF;
+		assert.throws(() => {
+			headerBysquare([0x00, 0x00, invalidValue, 0x00]);
+		}, new EncodeError(EncodeErrorMessage.DocumentType, { invalidValue }));
+	});
+	test("throw EncodeError when creating an bysquare header with invalid reserved nibble", () => {
+		const invalidValue = 0xFF;
+		assert.throws(() => {
+			headerBysquare([0x00, 0x00, 0x00, invalidValue]);
+		}, new EncodeError(EncodeErrorMessage.Reserved, { invalidValue }));
+	});
 });
 
 test("encode - binary header", () => {

--- a/src/encode.test.ts
+++ b/src/encode.test.ts
@@ -8,6 +8,8 @@ import {
 	EncodeError,
 	EncodeErrorMessage,
 	headerBysquare,
+	headerDataLength,
+	MAX_COMPRESSED_SIZE,
 	serialize,
 } from "./encode.js";
 import {
@@ -101,6 +103,20 @@ describe("encode - headerBysquare", function() {
 		assert.throws(() => {
 			headerBysquare([0x00, 0x00, 0x00, invalidValue]);
 		}, new EncodeError(EncodeErrorMessage.Reserved, { invalidValue }));
+	});
+});
+
+describe("encode - headerDataLength", function() {
+	test("return encoded header data length", function() {
+		const length = MAX_COMPRESSED_SIZE - 1;
+		const dataView = new DataView(new ArrayBuffer(2));
+		dataView.setUint16(0, length, true);
+		assert.deepEqual(
+			headerDataLength(length),
+			new Uint8Array(dataView.buffer),
+		);
+	});
+	test("throw, when length is too big", function() {
 	});
 });
 

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -10,6 +10,37 @@ import {
 } from "./types.js";
 import { validateDataModel } from "./validations.js";
 
+export enum EncodeErrorMessage {
+	/**
+	 * @description - find invalid value in extensions
+	 */
+	BySquareType = `Invalid BySquareType value in header, valid range <0,15>`,
+	/**
+	 * @description - find invalid value in extensions
+	 */
+	Version = `Invalid Version value in header, valid range <0,15>`,
+	/**
+	 * @description - find invalid value in extensions
+	 */
+	DocumentType = `Invalid DocumentType value in header, valid range <0,15>`,
+	/**
+	 * @description - find invalid value in extensions
+	 */
+	Reserved = `Invalid Reserved value in header, valid range <0,15>`,
+}
+
+export class EncodeError extends Error {
+	override name = "EncodeError";
+	public extensions?: { [name: string]: any; };
+
+	constructor(message: EncodeErrorMessage, extensions?: { [name: string]: any; }) {
+		super(message);
+		if (extensions) {
+			this.extensions = extensions;
+		}
+	}
+}
+
 const MAX_COMPRESSED_SIZE = 131_072; // 2^17
 
 /**
@@ -38,7 +69,7 @@ export function headerBysquare(
 	],
 ): Uint8Array {
 	if (header[0] < 0 || header[0] > 15) {
-		throw new Error(`Invalid BySquareType value '${header[0]}' in header, valid range <0,15>`);
+		throw new EncodeError(EncodeErrorMessage.BySquareType, { invalidValue: header[0] });
 	}
 	if (header[1] < 0 || header[1] > 15) {
 		throw new Error(`Invalid Version value '${header[1]}' in header, valid range <0,15>`);

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -17,8 +17,9 @@ export enum EncodeErrorMessage {
 	BySquareType = `Invalid BySquareType value in header, valid range <0,15>`,
 	/**
 	 * @description - find invalid value in extensions
+	 * @see {@link ./types#Version} for valid ranges
 	 */
-	Version = `Invalid Version value in header, valid range <0,15>`,
+	Version = `Invalid Version value in header`,
 	/**
 	 * @description - find invalid value in extensions
 	 */

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -28,6 +28,11 @@ export enum EncodeErrorMessage {
 	 * @description - find invalid value in extensions
 	 */
 	Reserved = `Invalid Reserved value in header, valid range <0,15>`,
+	/**
+	 * @description - find actual size of header in extensions
+	 * @see MAX_COMPRESSED_SIZE
+	 */
+	HeaderDataSize = `Allowed header data size exceeded`,
 }
 
 export class EncodeError extends Error {
@@ -107,7 +112,10 @@ export function headerBysquare(
  */
 export function headerDataLength(length: number): Uint8Array {
 	if (length >= MAX_COMPRESSED_SIZE) {
-		throw new Error(`Data size ${length} exceeds limit of ${MAX_COMPRESSED_SIZE} bytes`);
+		throw new EncodeError(EncodeErrorMessage.HeaderDataSize, {
+			actualSize: length,
+			allowedSize: MAX_COMPRESSED_SIZE,
+		});
 	}
 
 	const header = new ArrayBuffer(2);

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -60,26 +60,29 @@ const MAX_COMPRESSED_SIZE = 131_072; // 2^17
  * @see 3.5.
  */
 export function headerBysquare(
-	/** dprint-ignore */
 	header: [
-		bySquareType: number, version: number,
-		documentType: number, reserved: number
+		bySquareType: number,
+		version: number,
+		documentType: number,
+		reserved: number,
 	] = [
-		0x00, 0x00,
-		0x00, 0x00
+		0x00,
+		0x00,
+		0x00,
+		0x00,
 	],
 ): Uint8Array {
 	if (header[0] < 0 || header[0] > 15) {
 		throw new EncodeError(EncodeErrorMessage.BySquareType, { invalidValue: header[0] });
 	}
 	if (header[1] < 0 || header[1] > 15) {
-		throw new Error(`Invalid Version value '${header[1]}' in header, valid range <0,15>`);
+		throw new EncodeError(EncodeErrorMessage.Version, { invalidValue: header[1] });
 	}
 	if (header[2] < 0 || header[2] > 15) {
-		throw new Error(`Invalid DocumentType value '${header[2]}' in header, valid range <0,15>`);
+		throw new EncodeError(EncodeErrorMessage.DocumentType, { invalidValue: header[2] });
 	}
 	if (header[3] < 0 || header[3] > 15) {
-		throw new Error(`Invalid Reserved value '${header[3]}' in header, valid range <0,15>`);
+		throw new EncodeError(EncodeErrorMessage.Reserved, { invalidValue: header[3] });
 	}
 
 	const [

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -42,7 +42,7 @@ export class EncodeError extends Error {
 	}
 }
 
-const MAX_COMPRESSED_SIZE = 131_072; // 2^17
+export const MAX_COMPRESSED_SIZE = 131_072; // 2^17
 
 /**
  * Returns a 2 byte buffer that represents the header of the bysquare

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -65,16 +65,13 @@ export const MAX_COMPRESSED_SIZE = 131_072; // 2^17
  * @see 3.5.
  */
 export function headerBysquare(
+	/** dprint-ignore */
 	header: [
-		bySquareType: number,
-		version: number,
-		documentType: number,
-		reserved: number,
+		bySquareType: number, version: number,
+		documentType: number, reserved: number
 	] = [
-		0x00,
-		0x00,
-		0x00,
-		0x00,
+		0x00, 0x00,
+		0x00, 0x00
 	],
 ): Uint8Array {
 	if (header[0] < 0 || header[0] > 15) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a08b5bfa-9f4d-435c-9a6b-5f4c2964f3ef)

Hi @xseman. Please check the implementation. The main change is, that I have introduced the `EncodeError` class with the `EncodeErrorMessage` enum. What do you think about that approach?